### PR TITLE
Edit KontaktSkjemaHandler  dummy account get

### DIFF
--- a/force-app/main/kontaktskjema/classes/KontaktSkjemaHandler.cls
+++ b/force-app/main/kontaktskjema/classes/KontaktSkjemaHandler.cls
@@ -38,6 +38,15 @@ global with sharing class KontaktSkjemaHandler {
 
         CustomOpportunity__c co = createOpportunity(accountId, contactId, rw);
 
+        // If no organization number is set, update contact with dummy account
+        if (rw.organisationNumber == null){
+            List<Account> dummyAccount =  [SELECT ID FROM Account WHERE Name = 'Kontakter uten konto'];
+            Id i = dummyAccount[0].id;
+            List<Contact> currentContact =[SELECT ID, accountId FROM Contact WHERE Id = :contactId];
+            currentContact[0].accountId = i;
+            update currentContact;
+        }
+
         sendEmailReceipt(rw, co);
 
         return [SELECT Name FROM CustomOpportunity__c WHERE Id = :co.Id LIMIT 1].Name;

--- a/force-app/main/kontaktskjema/classes/KontaktSkjemaHandlerTest.cls
+++ b/force-app/main/kontaktskjema/classes/KontaktSkjemaHandlerTest.cls
@@ -1141,6 +1141,62 @@ private without sharing class KontaktSkjemaHandlerTest {
         }
     }
 
+    @isTest
+    private static void other_setDummyAccount() {
+        insert new Account(name = 'Kontakter uten konto', INT_OrganizationNumber__c = '960507878');
+
+        List<Account> dummyAccountTest = [SELECT Id FROM Account WHERE name ='Kontakter uten konto'];
+        Id y = dummyAccountTest[0].Id;
+
+        List<CustomOpportunity__c> CustomOpportunities = [SELECT Id FROM CustomOpportunity__c];
+        System.assertEquals(0, CustomOpportunities.size(), 'Size should be zero before');
+
+        RestRequest req = new RestRequest();
+        RestResponse res = new RestResponse();
+
+        req.requestURI = '/services/apexrest/ContactForm';
+        req.httpMethod = 'POST';
+        req.requestBody = Blob.valueof(
+            '{ "type":"FOREBYGGE_SYKEFRAVÆR","municipalityCode":"3033","organisationName":"Finstadtunet","firstName":"TestNavn","lastName":"TestEtternavn","email":"test@nav.no","phoneNo":"90080900","RegionCode":"0200" }'
+        );
+        RestContext.request = req;
+        RestContext.response = res;
+
+        Test.startTest();
+        KontaktSkjemaHandler.doPost();
+        Test.stopTest();
+
+        CustomOpportunities = [
+            SELECT
+                Id,
+                InquiryCategory__c,
+                RecordTypeId,
+                INT_RegionNumber__c,
+                INT_MunicipalityNumber__c,
+                TAG_OrganizationNameFromForm__c,
+                Contact__r.FirstName,
+                Contact__r.LastName,
+                Contact__r.AccountId,
+                Contact__r.Email,
+                Contact__r.MobilePhone,
+                Account__r.INT_OrganizationNumber__c
+            FROM CustomOpportunity__c
+        ];
+        System.assertEquals(1, CustomOpportunities.size(), 'Size should be one after insert');
+
+          System.assertEquals(
+            'TestEtternavn',
+            CustomOpportunities[0].Contact__r.LastName,
+            'Account is null as no org number was added to the request'
+        );
+
+          System.assertEquals(
+            y,
+            CustomOpportunities[0].Contact__r.AccountId,
+            'Account is null as no org number was added to the request'
+        );
+    }
+
     private static User getTestUser() {
         return [SELECT Id FROM User WHERE UserName = 'test@nav.apextest'];
     }

--- a/force-app/main/kontaktskjema/classes/KontaktSkjemaHandlerTest.cls
+++ b/force-app/main/kontaktskjema/classes/KontaktSkjemaHandlerTest.cls
@@ -756,8 +756,11 @@ private without sharing class KontaktSkjemaHandlerTest {
 
     @isTest // ! tests the Opportunity process to make sure contacts receive an account after adding an account manually to the opty (happens if a user does not input org number in the web form)
     private static void other_addingAccountAfterReuqestReceived() {
-        Account acc = new Account(name = 'test', INT_OrganizationNumber__c = '960507878');
+        Account acc = new Account(name = 'Kontakter uten konto', INT_OrganizationNumber__c = '960507878');
         insert acc;
+
+        List<Account> dummyAccountTest = [SELECT Id FROM Account WHERE name ='Kontakter uten konto'];
+        Id y = dummyAccountTest[0].Id;
 
         List<CustomOpportunity__c> customOpportunities = [SELECT Id FROM CustomOpportunity__c];
         System.assertEquals(0, customOpportunities.size(), 'Size should be zero before');
@@ -797,9 +800,9 @@ private without sharing class KontaktSkjemaHandlerTest {
         customOpportunities[0].Account__c = acc.Id;
 
         System.assertEquals(
-            null,
+            y,
             customOpportunities[0].Contact__r.AccountId,
-            'No account on contact as no account on opty'
+            'Dummy account set on contact as no account on opty'
         );
 
         update customOpportunities;
@@ -871,7 +874,10 @@ private without sharing class KontaktSkjemaHandlerTest {
 
     @isTest
     private static void other_noOrgNumber() {
-        insert new Account(name = 'test', INT_OrganizationNumber__c = '960507878');
+        insert new Account(name = 'Kontakter uten konto', INT_OrganizationNumber__c = '960507878');
+
+        List<Account> dummyAccountTest = [SELECT Id FROM Account WHERE name ='Kontakter uten konto'];
+        Id y = dummyAccountTest[0].Id;
 
         List<CustomOpportunity__c> CustomOpportunities = [SELECT Id FROM CustomOpportunity__c];
         System.assertEquals(0, CustomOpportunities.size(), 'Size should be zero before');
@@ -955,9 +961,9 @@ private without sharing class KontaktSkjemaHandlerTest {
             'Account is null as no org number was added to the request'
         );
         System.assertEquals(
-            null,
+            y,
             CustomOpportunities[0].Contact__r.AccountId,
-            'Account is null as no org number was added to the request'
+            'Dummy account set on contact as no org number was added to the request'
         );
     }
 
@@ -1185,15 +1191,15 @@ private without sharing class KontaktSkjemaHandlerTest {
         System.assertEquals(1, CustomOpportunities.size(), 'Size should be one after insert');
 
           System.assertEquals(
-            'TestEtternavn',
-            CustomOpportunities[0].Contact__r.LastName,
+            null,
+            CustomOpportunities[0].Account__c,
             'Account is null as no org number was added to the request'
         );
 
           System.assertEquals(
             y,
             CustomOpportunities[0].Contact__r.AccountId,
-            'Account is null as no org number was added to the request'
+            'Dummy account set on contact as no org number was added to the request'
         );
     }
 


### PR DESCRIPTION
- Edit KontaktSkjemaHandler so that if no organisation number is entered, the contact is connected to a dummy account