### PR TITLE
Replaced deprecated add-on with built-in function

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,6 @@
         "salesforce.salesforcedx-vscode",
         "aaron-bond.better-comments",
         "ChakrounAnas.turbo-console-log",
-        "CoenraadS.bracket-pair-colorizer-2",
         "dbaeumer.vscode-eslint",
         "donjayamanne.githistory",
         "eamodio.gitlens",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,5 +28,6 @@
         "**/.sfdx": true,
         "**/.vscode": true,
         "**/.idea": true
-    }
+    },
+    "editor.guides.bracketPairs": true
 }


### PR DESCRIPTION
Removed bracketPairColorization (https://marketplace.visualstudio.com/items?itemName=CoenraadS.bracket-pair-colorizer-2). 
Why: This extension is deprecated as this functionality is now built-in to VS Code. Enabled the built-in function in vscode settings.