### PR TITLE
Handling of subthemes

### DIFF
--- a/force-app/main/fia/classes/FiaCooperationHandler.cls
+++ b/force-app/main/fia/classes/FiaCooperationHandler.cls
@@ -139,17 +139,16 @@ public without sharing class FiaCooperationHandler extends KafkaMessageProcessor
             IATheme__c iaTheme = createTheme(tema, fiaCooperation);
             iaThemesToUpsert.add(iaTheme);
 
-            //Continue to next iteration
+            //Continue to next iteration if undertemaer is null
             if (tema.undertemaer == null) {
                 continue;
             }
 
             for (FiaCooperation.Undertema undertema : tema.undertemaer) {
-                // Update if included is true or if not included and status shows it was removed. Skip update if not included and status is blank
-                if (undertema.inkludert || (!undertema.inkludert && undertema.status == 'SLETTET')) {
-                    IA_Subtheme__c iaSubtheme = createSubtheme(undertema, tema.id, fiaCooperation);
-                    iaSubthemesToUpsert.add(iaSubtheme);
-                }
+                //Use handleSubthemeV1 before fia-changes
+                handleSubthemeV1(undertema, tema.id, fiaCooperation);
+                //Switch to handleSubthemeV2 when fia-changes goes live
+                //handleSubthemeV2(undertema, tema.id, fiaCooperation);
             }
         }
     }
@@ -180,7 +179,7 @@ public without sharing class FiaCooperationHandler extends KafkaMessageProcessor
             iaCooperation.PlanLastModified__c = fiaCooperation.plan.sistEndret;
             iaCooperation.PlanLastPublished__c = fiaCooperation.plan.sistPublisert;
             iaCooperation.PlanLastPublished__c = fiaCooperation.plan.sistPublisert;
-            //ToDo: Legg til plan.Status
+            iaCooperation.PlanStatus__c = fiaCooperation.plan.status;
         }
         return iaCooperation;
     }
@@ -215,6 +214,27 @@ public without sharing class FiaCooperationHandler extends KafkaMessageProcessor
             IA_CooperationTheme__r = new IACooperation__c(CooperationId__c = fiaCooperation.samarbeid.id)
         );
         return iaSubtheme;
+    }
+
+    private void handleSubthemeV1(
+        FiaCooperation.Undertema undertema,
+        String iaThemeReference,
+        FiaCooperation fiaCooperation
+    ) {
+        IA_Subtheme__c iaSubtheme = createSubtheme(undertema, tema.id, fiaCooperation);
+        iaSubthemesToUpsert.add(iaSubtheme);
+    }
+
+    private void handleSubthemeV2(
+        FiaCooperation.Undertema undertema,
+        String iaThemeReference,
+        FiaCooperation fiaCooperation
+    ) {
+        // Update if included is true or if not included and status shows it was removed. Skip update if not included and status is blank
+        if (undertema.inkludert || (!undertema.inkludert && undertema.status == 'SLETTET')) {
+            IA_Subtheme__c iaSubtheme = createSubtheme(undertema, tema.id, fiaCooperation);
+            iaSubthemesToUpsert.add(iaSubtheme);
+        }
     }
 
     // Helper method to set a field only if the value is not blank

--- a/force-app/main/fia/classes/FiaCooperationHandler.cls
+++ b/force-app/main/fia/classes/FiaCooperationHandler.cls
@@ -221,7 +221,7 @@ public without sharing class FiaCooperationHandler extends KafkaMessageProcessor
         String iaThemeReference,
         FiaCooperation fiaCooperation
     ) {
-        IA_Subtheme__c iaSubtheme = createSubtheme(undertema, tema.id, fiaCooperation);
+        IA_Subtheme__c iaSubtheme = createSubtheme(undertema, iaThemeReference, fiaCooperation);
         iaSubthemesToUpsert.add(iaSubtheme);
     }
 
@@ -232,7 +232,7 @@ public without sharing class FiaCooperationHandler extends KafkaMessageProcessor
     ) {
         // Update if included is true or if not included and status shows it was removed. Skip update if not included and status is blank
         if (undertema.inkludert || (!undertema.inkludert && undertema.status == 'SLETTET')) {
-            IA_Subtheme__c iaSubtheme = createSubtheme(undertema, tema.id, fiaCooperation);
+            IA_Subtheme__c iaSubtheme = createSubtheme(undertema, iaThemeReference, fiaCooperation);
             iaSubthemesToUpsert.add(iaSubtheme);
         }
     }

--- a/force-app/main/fia/classes/FiaCooperationHandlerTest.cls
+++ b/force-app/main/fia/classes/FiaCooperationHandlerTest.cls
@@ -199,7 +199,8 @@ private class FiaCooperationHandlerTest {
         );
         Assert.areEqual(3, cooperationRecord.IA_Themes__r.size(), 'Should have 3 themes');
         Assert.areEqual(1, cooperationRecord.IA_Themes__r[0].IA_Subthemes__r.size(), 'Should have 1 subtheme');
-        Assert.areEqual(2, cooperationRecord.IA_Themes__r[1].IA_Subthemes__r.size(), 'Should have 2 subthemes');
+        Assert.areEqual(4, cooperationRecord.IA_Themes__r[1].IA_Subthemes__r.size(), 'Should have 4 subthemes');
+        //Assert.areEqual(2, cooperationRecord.IA_Themes__r[1].IA_Subthemes__r.size(), 'Should have 2 subthemes');
         Assert.areEqual(0, cooperationRecord.IA_Themes__r[2].IA_Subthemes__r.size(), 'Should have 0 subthemes');
 
         Assert.isTrue(

--- a/force-app/main/fia/classes/FiaCooperationHandlerTest.cls
+++ b/force-app/main/fia/classes/FiaCooperationHandlerTest.cls
@@ -201,7 +201,8 @@ private class FiaCooperationHandlerTest {
         Assert.areEqual(1, cooperationRecord.IA_Themes__r[0].IA_Subthemes__r.size(), 'Should have 1 subtheme');
         Assert.areEqual(4, cooperationRecord.IA_Themes__r[1].IA_Subthemes__r.size(), 'Should have 4 subthemes');
         //Assert.areEqual(2, cooperationRecord.IA_Themes__r[1].IA_Subthemes__r.size(), 'Should have 2 subthemes');
-        Assert.areEqual(0, cooperationRecord.IA_Themes__r[2].IA_Subthemes__r.size(), 'Should have 0 subthemes');
+        Assert.areEqual(6, cooperationRecord.IA_Themes__r[2].IA_Subthemes__r.size(), 'Should have 6 subthemes');
+        //Assert.areEqual(0, cooperationRecord.IA_Themes__r[2].IA_Subthemes__r.size(), 'Should have 0 subthemes');
 
         Assert.isTrue(
             cooperationRecord.IncludedPartssamarbeid__c,

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -56,7 +56,7 @@
                 },
                 {
                     "package": "crm-arbeidsgiver-base",
-                    "versionNumber": "1.461.0.LATEST"
+                    "versionNumber": "1.467.0.LATEST"
                 }
             ]
         }


### PR DESCRIPTION
Currently, all subthemes must be created/updated to ensure a subtheme is updated in SF if it is removed in Fia. In  future change in Fia, a removed subtheme will be detectable based on status. Code should then only update subthemes that are included or removed. Change in logic is dependent on changes in Fia. 
To prepare for the change I moved logic into two separate methods and added comments as placeholders. This should make swapping easier and reduce risks. 

Also added mapping for plan status.