### PR TITLE
Updated logError method: Removed category

### DIFF
--- a/force-app/main/fia/classes/FiaCooperationHandler.cls
+++ b/force-app/main/fia/classes/FiaCooperationHandler.cls
@@ -285,7 +285,7 @@ public without sharing class FiaCooperationHandler extends KafkaMessageProcessor
         List<KafkaMessage__c> kafkaMessages
     ) {
         System.debug(stackTrace);
-        String errorRef = logger.logError('FiaCooperationHandler', referenceInfo, message, stackTrace);
+        String errorRef = logger.logError(referenceInfo, message, stackTrace);
         logger.setMessageErrors(kafkaMessages, errorRef);
     }
 

--- a/force-app/main/shared/kafka/classes/AG_KafkaLogger.cls
+++ b/force-app/main/shared/kafka/classes/AG_KafkaLogger.cls
@@ -41,10 +41,9 @@ public with sharing class AG_KafkaLogger {
         return errorRef;
     }
 
-    public String logError(String category, String referenceInfo, String message, String stacktrace) {
+    public String logError(String referenceInfo, String message, String stacktrace) {
         LoggerUtility.LogLevel logLevel = LoggerUtility.LogLevel.Error;
         String errorRef = '';
-        logger.setCategory(category); //Category within application domain to allow for further filtering og logs. text(32)
         logger.logMessage(
             logLevel,
             errorRef,


### PR DESCRIPTION
Klassenavn ble logget i ApplicationLog__c.Category__c, men dette gjør at loggen ikke publiseres til Slack. Fjernet dette.