### PR TITLE
Bug på IA-samarbeid

### DIFF
--- a/force-app/main/fia/classes/FiaCooperationHandler.cls
+++ b/force-app/main/fia/classes/FiaCooperationHandler.cls
@@ -121,32 +121,75 @@ public without sharing class FiaCooperationHandler extends KafkaMessageProcessor
         Map<String, FiaCooperation.Plan> fiaPlanMap = new Map<String, FiaCooperation.Plan>();
         for (FiaCooperation fiaCooperation : allFiaCooperationUpdates) {
             String cooperationId = fiaCooperation.samarbeid.id;
-            // Add or replace entry in the cooperation map
-            FiaCooperation existing = fiaSamarbeidMap.get(fiaCooperation.samarbeid.id);
-            Boolean isNewerCooperation = (existing == null ||
-            existing.samarbeid.endretTidspunkt < fiaCooperation.samarbeid.endretTidspunkt);
-            if (!fiaSamarbeidMap.containsKey(cooperationId) || isNewerCooperation) {
+            // Determine the newest cooperation
+            FiaCooperation existingCooperation = fiaSamarbeidMap.get(cooperationId);
+            if (isNewerCooperation(existingCooperation, fiaCooperation)) {
                 fiaSamarbeidMap.put(cooperationId, fiaCooperation);
             }
+            // Determine the newest plan
             if (fiaCooperation.plan != null) {
-                // Add or replace entry in the plan map
-                FiaCooperation.Plan existingPlan = fiaPlanMap.get(fiaCooperation.samarbeid.id);
-                Boolean isNewerPlan = (existingPlan == null ||
-                existingPlan.sistEndret < fiaCooperation.plan.sistEndret);
-                if (!fiaPlanMap.containsKey(cooperationId) || isNewerPlan) {
+                FiaCooperation.Plan existingPlan = fiaPlanMap.get(cooperationId);
+                if (isNewerPlan(existingPlan, fiaCooperation.plan)) {
                     fiaPlanMap.put(cooperationId, fiaCooperation.plan);
                 }
             }
         }
-        //have map with most recent of each type, now combine in one map and return it as list.
-        for (String cooperationId : fiaSamarbeidMap.keySet()) {
-            if (fiaPlanMap.containsKey(cooperationId)) {
-                fiaSamarbeidMap.get(cooperationId).plan = fiaPlanMap.get(cooperationId);
-            }
-        }
-        return fiaSamarbeidMap;
+        // Combine cooperation and plan maps
+        return combineCooperationAndPlanMaps(fiaSamarbeidMap, fiaPlanMap);
     }
 
+    /**
+     * @description Determines if the given cooperation is newer than the existing one.
+     * @param existingCooperation The existing cooperation object.
+     * @param newCooperation The new cooperation object.
+     * @return True if the new cooperation is newer, false otherwise.
+     */
+    @testVisible
+    private static Boolean isNewerCooperation(FiaCooperation existingCooperation, FiaCooperation newCooperation) {
+        Datetime existingCooperationTime = existingCooperation?.samarbeid?.endretTidspunkt;
+        Datetime newCooperationTime = newCooperation?.samarbeid?.endretTidspunkt;
+
+        if (existingCooperationTime == null && newCooperationTime == null) {
+            return false; // Both are null, consider them equal
+        }
+        if (existingCooperationTime == null) {
+            return true; // Existing is null, new is newer
+        }
+        if (newCooperationTime == null) {
+            return false; // New is null, existing is newer
+        }
+        return existingCooperationTime < newCooperationTime; // Compare timestamps
+    }
+
+    /**
+     * @description Determines if the given plan is newer than the existing one.
+     * @param existingPlan The existing plan object.
+     * @param newPlan The new plan object.
+     * @return True if the new plan is newer, false otherwise.
+     */
+    @testVisible
+    private static Boolean isNewerPlan(FiaCooperation.Plan existingPlan, FiaCooperation.Plan newPlan) {
+        return existingPlan == null || existingPlan.sistEndret < newPlan.sistEndret;
+    }
+
+    /**
+     * @description Combines the cooperation and plan maps into a single map.
+     * @param cooperationMap Map of cooperation objects.
+     * @param planMap Map of plan objects.
+     * @return Combined map of cooperation objects with their plans.
+     */
+    @testVisible
+    private static Map<String, FiaCooperation> combineCooperationAndPlanMaps(
+        Map<String, FiaCooperation> cooperationMap,
+        Map<String, FiaCooperation.Plan> planMap
+    ) {
+        for (String cooperationId : cooperationMap.keySet()) {
+            if (planMap.containsKey(cooperationId)) {
+                cooperationMap.get(cooperationId).plan = planMap.get(cooperationId);
+            }
+        }
+        return cooperationMap;
+    }
     /**
      * @description Creates a list of deleted IDs based on the provided FiaCooperation objects.
      * @param updates List of FiaCooperation objects to process for deletions.

--- a/force-app/main/fia/classes/FiaCooperationHandlerTest.cls
+++ b/force-app/main/fia/classes/FiaCooperationHandlerTest.cls
@@ -807,4 +807,70 @@ private class FiaCooperationHandlerTest {
         List<IACooperation__c> deletedRecords = [SELECT Id FROM IACooperation__c WHERE CooperationId__c IN ('1', '2')];
         System.assertEquals(0, deletedRecords.size(), 'Records should be deleted.');
     }
+
+    @isTest
+    static void testIsNewerCooperation() {
+        FiaCooperation existingCooperation = new FiaCooperation();
+        FiaCooperation newCooperation = new FiaCooperation();
+
+        newCooperation.samarbeid = new FiaCooperation.Samarbeid();
+        newCooperation.samarbeid.endretTidspunkt = Datetime.newInstance(2025, 1, 1, 0, 0, 0);
+        Assert.isTrue(
+            FiaCooperationHandler.isNewerCooperation(existingCooperation, newCooperation),
+            'New cooperation should be considered newer if existing cooperation is null.'
+        );
+
+        existingCooperation.samarbeid = new FiaCooperation.Samarbeid();
+        Assert.isTrue(
+            FiaCooperationHandler.isNewerCooperation(existingCooperation, newCooperation),
+            'New cooperation should be considered newer if existing cooperation endretTidspunkt is null.'
+        );
+
+        // Set newer date
+        existingCooperation.samarbeid.endretTidspunkt = Datetime.newInstance(2025, 1, 1, 0, 0, 1);
+        Assert.isFalse(
+            FiaCooperationHandler.isNewerCooperation(existingCooperation, newCooperation),
+            'Existing cooperation date should be considered newer.'
+        );
+
+        newCooperation.samarbeid.endretTidspunkt = null;
+        Assert.isFalse(
+            FiaCooperationHandler.isNewerCooperation(existingCooperation, newCooperation),
+            'Existing cooperation date should be considered newer when compared to null.'
+        );
+    }
+
+    @isTest
+    static void testIsNewerPlan() {
+        FiaCooperation.Plan oldPlan = new FiaCooperation.Plan();
+        oldPlan.sistEndret = Datetime.newInstance(2023, 1, 1, 0, 0, 0);
+
+        FiaCooperation.Plan newPlan = new FiaCooperation.Plan();
+        newPlan.sistEndret = Datetime.newInstance(2023, 6, 1, 0, 0, 0);
+
+        Boolean result = FiaCooperationHandler.isNewerPlan(oldPlan, newPlan);
+        System.assert(result, 'New plan should be considered newer.');
+    }
+
+    @isTest
+    static void testCombineCooperationAndPlanMaps() {
+        Map<String, FiaCooperation> cooperationMap = new Map<String, FiaCooperation>();
+        Map<String, FiaCooperation.Plan> planMap = new Map<String, FiaCooperation.Plan>();
+
+        FiaCooperation cooperation = new FiaCooperation();
+        cooperation.samarbeid = new FiaCooperation.Samarbeid();
+        cooperation.samarbeid.id = '1';
+
+        FiaCooperation.Plan plan = new FiaCooperation.Plan();
+        plan.sistEndret = Datetime.newInstance(2023, 6, 1, 0, 0, 0);
+
+        cooperationMap.put('1', cooperation);
+        planMap.put('1', plan);
+
+        Map<String, FiaCooperation> result = FiaCooperationHandler.combineCooperationAndPlanMaps(
+            cooperationMap,
+            planMap
+        );
+        System.assert(result.get('1').plan != null, 'Plan should be combined with cooperation.');
+    }
 }

--- a/force-app/main/fia/classes/FiaCooperationHandlerTest.cls-meta.xml
+++ b/force-app/main/fia/classes/FiaCooperationHandlerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>63.0</apiVersion>
     <status>Active</status>
 </ApexClass>


### PR DESCRIPTION
Når flere kafka meldinger prosesseres så er det er logikk som skal plukke den nyeste informasjonen basert på endretTidspunkt. Samarbeidet har ikke alltid noe endretTidspunkt, og da blir feil data brukt siden sammenligningen dato1 > dato2 er false dersom en av datoene er null. Oppdatert kode så null-dato ikke tolkes som nyere melding.