### PR TITLE
Enhance condition in createRecords to check for deleted plan status

### DIFF
--- a/force-app/main/fia/classes/FiaCooperationHandler.cls
+++ b/force-app/main/fia/classes/FiaCooperationHandler.cls
@@ -244,7 +244,7 @@ public without sharing class FiaCooperationHandler extends KafkaMessageProcessor
 
                 IACooperation__c iaCooperation = createIACooperation(fiaCooperation);
                 iaCooperationsToUpsert.add(iaCooperation);
-                if (fiaCooperation.plan?.temaer == null) {
+                if (fiaCooperation.plan?.temaer == null || fiaCooperation.plan.status == STATUS_DELETED) {
                     continue;
                 }
                 for (FiaCooperation.Tema tema : fiaCooperation.plan.temaer) {

--- a/force-app/main/fia/classes/FiaCooperationHandler.cls
+++ b/force-app/main/fia/classes/FiaCooperationHandler.cls
@@ -244,7 +244,7 @@ public without sharing class FiaCooperationHandler extends KafkaMessageProcessor
 
                 IACooperation__c iaCooperation = createIACooperation(fiaCooperation);
                 iaCooperationsToUpsert.add(iaCooperation);
-                if (fiaCooperation.plan?.temaer == null || fiaCooperation.plan.status == STATUS_DELETED) {
+                if (fiaCooperation.plan?.temaer == null || fiaCooperation.plan?.status == STATUS_DELETED) {
                     continue;
                 }
                 for (FiaCooperation.Tema tema : fiaCooperation.plan.temaer) {


### PR DESCRIPTION
Fixes issue when deleted plan is the most recent update, then themes are first deleted (intended behaviour) and then created (not intended behaviour).
Added condition to prevent theme and subtheme upserts if they belong to a deleted plan.